### PR TITLE
Issue with Free Lunch font

### DIFF
--- a/src/lib/getUrl.ts
+++ b/src/lib/getUrl.ts
@@ -10,7 +10,7 @@ if(process.env.VERCEL) {
     return DEFAULT;
   }
 
-  return process.env.VERCEL_URL ? process.env.VERCEL_URL : DEFAULT;
+  return process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : DEFAULT;
 
 }
 return DEFAULT;


### PR DESCRIPTION
My current version of Free Lunch has an issue where any word that begins with "T" is being ligatured with the previous letter and ignoring the space.

This is currently being handled by inserting `<span className="inline-block w-0">&nbsp;</span>` between those words.

![image](https://github.com/danieltott/danott.dev/assets/360261/0d8927d9-0b77-47b2-b0e1-3922121464ac)

![image](https://github.com/danieltott/danott.dev/assets/360261/4229ce9d-e5e0-46c2-8848-6202719f0bff)
